### PR TITLE
fix: Cart items don't update

### DIFF
--- a/src/Cart/Cart.php
+++ b/src/Cart/Cart.php
@@ -3,6 +3,7 @@
 namespace Azuriom\Plugin\Shop\Cart;
 
 use Azuriom\Plugin\Shop\Models\Concerns\Buyable;
+use Azuriom\Plugin\Shop\Models\Package;
 use Illuminate\Session\Store as Session;
 
 /**
@@ -37,7 +38,15 @@ class Cart
     public function __construct(Session $session = null)
     {
         $this->session = $session;
-        $this->items = collect($this->session ? $this->session->get('shop.cart', []) : []);
+        $this->items = collect([]);
+
+        $sessionItems = $this->session ? $this->session->get('shop.cart', []) : [];
+        $this->session->remove('shop.cart');
+
+        foreach ($sessionItems as $sessionItem) {
+            $refreshedPackage = Package::where("id", "=", $sessionItem->id)->get()->first();
+            $this->add($refreshedPackage, $sessionItem->quantity);
+        }
     }
 
     /**
@@ -56,7 +65,7 @@ class Cart
             return;
         }
 
-        $this->set($buyable, 1);
+        $this->set($buyable, $quantity);
     }
 
     /**

--- a/src/Cart/CartItem.php
+++ b/src/Cart/CartItem.php
@@ -59,6 +59,7 @@ class CartItem
      */
     public function __construct(Buyable $buyable, string $itemId, int $quantity = 1)
     {
+        $this->associatedModel = $buyable;
         $this->id = $buyable->id;
         $this->itemId = $itemId;
         $this->type = get_class($buyable);

--- a/src/Events/PackageDelivered.php
+++ b/src/Events/PackageDelivered.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Azuriom\Events;
+namespace Azuriom\Plugin\Shop\Events;
 
 use Azuriom\Plugin\Shop\Models\Package;
 use Illuminate\Queue\SerializesModels;

--- a/src/Models/Package.php
+++ b/src/Models/Package.php
@@ -2,7 +2,7 @@
 
 namespace Azuriom\Plugin\Shop\Models;
 
-use Azuriom\Events\PackageDelivered;
+use Azuriom\Plugin\Shop\Events\PackageDelivered;
 use Azuriom\Models\Server;
 use Azuriom\Models\Traits\HasImage;
 use Azuriom\Models\Traits\HasTablePrefix;


### PR DESCRIPTION
When you update a package in the admin panel, it doesn't update in current carts and players can buy items with previous price and commands are the previous ones as well. It's quite annoying so here is a fix.