### PR TITLE
Use the new PayPal Checkout SDK

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "mollie/mollie-api-php": "^2.12.0",
         "paymentwall/paymentwall-php": "^2.2",
         "paygol/php-sdk": "^1.0",
-        "paypal/rest-api-sdk-php": "^1.14.0",
+        "paypal/paypal-checkout-sdk": "^1.0.1",
         "stripe/stripe-php": "^7.14",
         "xsolla/xsolla-sdk-php": "^4.1"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4033f5902f5e73bd2bac500c16ddc7a4",
+    "content-hash": "a529a489d2a859d58c4d079d8d41880c",
     "packages": [
         {
             "name": "composer/ca-bundle",
-            "version": "1.2.8",
+            "version": "1.2.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "8a7ecad675253e4654ea05505233285377405215"
+                "reference": "78a0e288fdcebf92aa2318a8d3656168da6ac1a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/8a7ecad675253e4654ea05505233285377405215",
-                "reference": "8a7ecad675253e4654ea05505233285377405215",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/78a0e288fdcebf92aa2318a8d3656168da6ac1a5",
+                "reference": "78a0e288fdcebf92aa2318a8d3656168da6ac1a5",
                 "shasum": ""
             },
             "require": {
@@ -26,14 +26,15 @@
                 "php": "^5.3.2 || ^7.0 || ^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || 6.5 - 8",
+                "phpstan/phpstan": "^0.12.55",
                 "psr/log": "^1.0",
+                "symfony/phpunit-bridge": "^4.2 || ^5",
                 "symfony/process": "^2.5 || ^3.0 || ^4.0 || ^5.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.x-dev"
+                    "dev-main": "1.x-dev"
                 }
             },
             "autoload": {
@@ -63,7 +64,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/ca-bundle/issues",
-                "source": "https://github.com/composer/ca-bundle/tree/1.2.8"
+                "source": "https://github.com/composer/ca-bundle/tree/1.2.9"
             },
             "funding": [
                 {
@@ -79,20 +80,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-08-23T12:54:47+00:00"
+            "time": "2021-01-12T12:10:35+00:00"
         },
         {
             "name": "mollie/mollie-api-php",
-            "version": "v2.24.0",
+            "version": "v2.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mollie/mollie-api-php.git",
-                "reference": "52bd606724109906d61226698c8b031ccae9e637"
+                "reference": "619349868112df2825d7a225d4e92f9fb7e9f2d8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mollie/mollie-api-php/zipball/52bd606724109906d61226698c8b031ccae9e637",
-                "reference": "52bd606724109906d61226698c8b031ccae9e637",
+                "url": "https://api.github.com/repos/mollie/mollie-api-php/zipball/619349868112df2825d7a225d4e92f9fb7e9f2d8",
+                "reference": "619349868112df2825d7a225d4e92f9fb7e9f2d8",
                 "shasum": ""
             },
             "require": {
@@ -105,7 +106,8 @@
             },
             "require-dev": {
                 "eloquent/liberator": "^2.0",
-                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.1"
+                "friendsofphp/php-cs-fixer": "^v2.17",
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.1 || ^8.5"
             },
             "suggest": {
                 "mollie/oauth2-mollie-php": "Use OAuth to authenticate with the Mollie API. This is needed for some endpoints. Visit https://docs.mollie.com/ for more information."
@@ -167,9 +169,9 @@
             ],
             "support": {
                 "issues": "https://github.com/mollie/mollie-api-php/issues",
-                "source": "https://github.com/mollie/mollie-api-php/tree/v2.24.0"
+                "source": "https://github.com/mollie/mollie-api-php/tree/v2.29.0"
             },
-            "time": "2020-10-15T12:55:48+00:00"
+            "time": "2021-01-27T10:05:15+00:00"
         },
         {
             "name": "paygol/php-sdk",
@@ -271,71 +273,113 @@
             "time": "2019-04-24T04:28:11+00:00"
         },
         {
-            "name": "paypal/rest-api-sdk-php",
-            "version": "1.14.0",
+            "name": "paypal/paypal-checkout-sdk",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/paypal/PayPal-PHP-SDK.git",
-                "reference": "72e2f2466975bf128a31e02b15110180f059fc04"
+                "url": "https://github.com/paypal/Checkout-PHP-SDK.git",
+                "reference": "ed6a55075448308b87a8b59dcb7fedf04a048cb1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paypal/PayPal-PHP-SDK/zipball/72e2f2466975bf128a31e02b15110180f059fc04",
-                "reference": "72e2f2466975bf128a31e02b15110180f059fc04",
+                "url": "https://api.github.com/repos/paypal/Checkout-PHP-SDK/zipball/ed6a55075448308b87a8b59dcb7fedf04a048cb1",
+                "reference": "ed6a55075448308b87a8b59dcb7fedf04a048cb1",
                 "shasum": ""
             },
             "require": {
-                "ext-curl": "*",
-                "ext-json": "*",
-                "php": ">=5.3.0",
-                "psr/log": "^1.0.0"
+                "paypal/paypalhttp": "1.0.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35"
+                "phpunit/phpunit": "^5.7"
             },
             "type": "library",
             "autoload": {
-                "psr-0": {
-                    "PayPal": "lib/"
+                "psr-4": {
+                    "PayPalCheckoutSdk\\": "lib/PayPalCheckoutSdk",
+                    "Sample\\": "samples/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "Apache-2.0"
+                "https://github.com/paypal/Checkout-PHP-SDK/blob/master/LICENSE"
             ],
             "authors": [
                 {
                     "name": "PayPal",
-                    "homepage": "https://github.com/paypal/rest-api-sdk-php/contributors"
+                    "homepage": "https://github.com/paypal/Checkout-PHP-SDK/contributors"
                 }
             ],
-            "description": "PayPal's PHP SDK for REST APIs",
-            "homepage": "http://paypal.github.io/PayPal-PHP-SDK/",
+            "description": "PayPal's PHP SDK for Checkout REST APIs",
+            "homepage": "http://github.com/paypal/Checkout-PHP-SDK/",
             "keywords": [
+                "checkout",
+                "orders",
                 "payments",
                 "paypal",
                 "rest",
                 "sdk"
             ],
             "support": {
-                "issues": "https://github.com/paypal/PayPal-PHP-SDK/issues",
-                "source": "https://github.com/paypal/PayPal-PHP-SDK/tree/master"
+                "issues": "https://github.com/paypal/Checkout-PHP-SDK/issues",
+                "source": "https://github.com/paypal/Checkout-PHP-SDK/tree/1.0.1"
             },
-            "abandoned": true,
-            "time": "2019-01-04T20:04:25+00:00"
+            "time": "2019-11-07T23:16:44+00:00"
         },
         {
-            "name": "stripe/stripe-php",
-            "version": "v7.65.0",
+            "name": "paypal/paypalhttp",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/stripe/stripe-php.git",
-                "reference": "d4a22eeec7654efb8476fe8bea95b1e9928025a6"
+                "url": "https://github.com/paypal/paypalhttp_php.git",
+                "reference": "1ad9b846a046f09d6135cbf2cbaa7701bbc630a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/stripe/stripe-php/zipball/d4a22eeec7654efb8476fe8bea95b1e9928025a6",
-                "reference": "d4a22eeec7654efb8476fe8bea95b1e9928025a6",
+                "url": "https://api.github.com/repos/paypal/paypalhttp_php/zipball/1ad9b846a046f09d6135cbf2cbaa7701bbc630a3",
+                "reference": "1ad9b846a046f09d6135cbf2cbaa7701bbc630a3",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7",
+                "wiremock-php/wiremock-php": "1.43.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PayPalHttp\\": "lib/PayPalHttp"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PayPal",
+                    "homepage": "https://github.com/paypal/paypalhttp_php/contributors"
+                }
+            ],
+            "support": {
+                "issues": "https://github.com/paypal/paypalhttp_php/issues",
+                "source": "https://github.com/paypal/paypalhttp_php/tree/1.0.0"
+            },
+            "time": "2019-11-06T21:27:12+00:00"
+        },
+        {
+            "name": "stripe/stripe-php",
+            "version": "v7.69.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/stripe/stripe-php.git",
+                "reference": "6716cbc4ebf8cba7d45374a059c7c6e5bf53277d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/stripe/stripe-php/zipball/6716cbc4ebf8cba7d45374a059c7c6e5bf53277d",
+                "reference": "6716cbc4ebf8cba7d45374a059c7c6e5bf53277d",
                 "shasum": ""
             },
             "require": {
@@ -345,7 +389,7 @@
                 "php": ">=5.6.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "2.16.5",
+                "friendsofphp/php-cs-fixer": "2.17.1",
                 "php-coveralls/php-coveralls": "^2.1",
                 "phpunit/phpunit": "^5.7",
                 "squizlabs/php_codesniffer": "^3.3",
@@ -381,9 +425,9 @@
             ],
             "support": {
                 "issues": "https://github.com/stripe/stripe-php/issues",
-                "source": "https://github.com/stripe/stripe-php/tree/v7.65.0"
+                "source": "https://github.com/stripe/stripe-php/tree/v7.69.0"
             },
-            "time": "2020-11-19T19:37:25+00:00"
+            "time": "2021-01-22T03:21:13+00:00"
         },
         {
             "name": "xsolla/xsolla-sdk-php",

--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
     "id": "shop",
     "name": "Shop",
     "description": "A shop plugin to sell in-game items on your website.",
-    "version": "0.2.14",
+    "version": "0.2.15",
     "url": "https://azuriom.com/market/resources/1",
     "authors": [
         "Azuriom"

--- a/resources/views/payments/success.blade.php
+++ b/resources/views/payments/success.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts.app')
 
-@section('title', 'Payment')
+@section('title', trans('shop::messages.payment.title'))
 
 @section('content')
     <div class="container content">

--- a/src/Payment/Method/PayPalExpressCheckout.php
+++ b/src/Payment/Method/PayPalExpressCheckout.php
@@ -90,7 +90,7 @@ class PayPalExpressCheckout extends PaymentMethod
 
         $payment->update(['transaction_id' => $response->result->id]);
 
-        $approveLink = Arr::first($response->result->links, function ($link)  {
+        $approveLink = Arr::first($response->result->links, function ($link) {
             return $link->rel === 'approve';
         });
 

--- a/src/Payment/Method/PayPalExpressCheckout.php
+++ b/src/Payment/Method/PayPalExpressCheckout.php
@@ -90,6 +90,12 @@ class PayPalExpressCheckout extends PaymentMethod
 
         $response = $this->getClient()->execute($request);
 
+        if ($response->statusCode != 201) {
+        	logger()->warning('Error occured while creating order with PayPal.');
+
+        	abort(500);
+        }
+
         $payment->update(['transaction_id' => $response->result->id]);
 
         $approveLink = null;
@@ -116,7 +122,7 @@ class PayPalExpressCheckout extends PaymentMethod
         $payment = Payment::firstWhere('transaction_id', $token);
 
         if ($payment === null) {
-            logger()->warning('Invalid payment id: '.$token);
+            logger()->warning('Invalid order id: '.$token);
 
             return $this->errorResponse();
         }
@@ -127,7 +133,7 @@ class PayPalExpressCheckout extends PaymentMethod
 	        $response = $this->getClient()->execute($request);
             
             if ($response->statusCode != 201) {
-            	logger()->warning('Invalid response for '.$token);
+            	logger()->warning('Invalid response while capturing order '.$token);
 
             	return $this->errorResponse();
             }

--- a/src/Payment/Method/PayPalExpressCheckout.php
+++ b/src/Payment/Method/PayPalExpressCheckout.php
@@ -81,7 +81,7 @@ class PayPalExpressCheckout extends PaymentMethod
                                 'currency_code' => $currency,
                                 'value' => $total,
                             ],
-                        ]
+                        ],
                     ],
                     'items' => $items,
                 ],
@@ -131,7 +131,7 @@ class PayPalExpressCheckout extends PaymentMethod
             $request = new OrdersCaptureRequest($token);
 
             $response = $this->getClient()->execute($request);
-            
+
             if ($response->statusCode != 201) {
                 logger()->warning('Invalid response while capturing order '.$token);
 


### PR DESCRIPTION
Changelist:
- Switched from `paypal/rest-api-sdk-php` to `paypal/paypal-checkout-sdk`.
- Use trans() for the title of `success.blade.php`.

https://github.com/orgs/Azuriom/projects/1#card-37725853 needs update.