### PR TITLE
No self onDeleteCascade for SQLServer compatibility

### DIFF
--- a/database/migrations/2020_11_28_000000_add_parent_id_to_shop_categories_table.php
+++ b/database/migrations/2020_11_28_000000_add_parent_id_to_shop_categories_table.php
@@ -16,7 +16,7 @@ class AddParentIdToShopCategoriesTable extends Migration
         Schema::table('shop_categories', function (Blueprint $table) {
             $table->unsignedInteger('parent_id')->nullable()->after('position');
 
-            $table->foreign('parent_id')->references('id')->on('shop_categories')->cascadeOnDelete();
+            $table->foreign('parent_id')->references('id')->on('shop_categories');
         });
     }
 


### PR DESCRIPTION
Since we forbid the deletion of a category if it has children, see https://github.com/Azuriom/Plugin-Shop/blob/f233fd1b00971f082f918eb88297e32f9705403d/src/Controllers/Admin/CategoryController.php#L81 

the onDeleteCascade is not necessary and it create incompatibilities.