### PR TITLE
Prevent null given for embed discord

### DIFF
--- a/src/Models/Payment.php
+++ b/src/Models/Payment.php
@@ -120,7 +120,7 @@ class Payment extends Model
                     ->author($this->user->name, null, $this->user->getAvatar())
                     ->addField(trans('shop::messages.fields.price'), $this->price.' '.currency_display($this->currency))
                     ->addField(trans('messages.fields.type'), $this->getTypeName())
-                    ->addField(trans('shop::messages.fields.payment-id'), $this->transaction_id)
+                    ->addField(trans('shop::messages.fields.payment-id'), $this->transaction_id or 'Null')
                     ->url(route('shop.admin.payments.show', $this))
                     ->color('#004de6')
                     ->footer('Azuriom v'.Azuriom::version())

--- a/src/Models/Payment.php
+++ b/src/Models/Payment.php
@@ -120,7 +120,7 @@ class Payment extends Model
                     ->author($this->user->name, null, $this->user->getAvatar())
                     ->addField(trans('shop::messages.fields.price'), $this->price.' '.currency_display($this->currency))
                     ->addField(trans('messages.fields.type'), $this->getTypeName())
-                    ->addField(trans('shop::messages.fields.payment-id'), $this->transaction_id or 'Null')
+                    ->addField(trans('shop::messages.fields.payment-id'), $this->transaction_id ?? trans('messages.none'))
                     ->url(route('shop.admin.payments.show', $this))
                     ->color('#004de6')
                     ->footer('Azuriom v'.Azuriom::version())


### PR DESCRIPTION
as i mentioned in discord, i took a little test for giving 100% discount coupons for every user and they have error in page, so i look back in logs files, there are null given for the embed (when discord webhook is enabled), so this is the fix for that, CMIIW
