### PR TITLE
use ?? and not default value

### DIFF
--- a/resources/views/packages/show.blade.php
+++ b/resources/views/packages/show.blade.php
@@ -40,7 +40,7 @@
                             </div>
 
                             <div class="form-group mx-3">
-                                <input type="number" min="0" max="{{ $package->getMaxQuantity() }}" size="5" class="form-control" name="quantity" id="quantity" value="1">
+                                <input type="number" min="0" max="{{ $package->getMaxQuantity() }}" size="5" class="form-control" name="quantity" id="quantity" value="1" required>
                             </div>
                         @endif
 

--- a/src/Controllers/PackageController.php
+++ b/src/Controllers/PackageController.php
@@ -45,7 +45,7 @@ class PackageController extends Controller
             return redirect()->back()->with('error', trans('shop::messages.packages.requirements'));
         }
 
-        $cart->add($package, $request->input('quantity', 1));
+        $cart->add($package, $request->input('quantity') ?? 1);
 
         return redirect()->route('shop.cart.index');
     }


### PR DESCRIPTION
For unknown reasons `$quantity` can be null, using `??` operator fixes the issue. The default values was not used as expected

`Azuriom\Plugin\Shop\Cart\Cart::add(): Argument #2 ($quantity) must be of type int, null given, called in /var/www/xxx/plugins/shop/src/Controllers/PackageController.php on line 48`