### PR TITLE
Paypal Express does not accept float payments

### DIFF
--- a/src/Cart/Cart.php
+++ b/src/Cart/Cart.php
@@ -204,9 +204,9 @@ class Cart implements Arrayable
      */
     public function total()
     {
-        return $this->content()->sum(function (CartItem $cartItem) {
+        return round($this->content()->sum(function (CartItem $cartItem) {
             return $cartItem->total();
-        });
+        }), 2);
     }
 
     protected function getItemId(Buyable $buyable)

--- a/src/Payment/Method/PayPalExpressCheckout.php
+++ b/src/Payment/Method/PayPalExpressCheckout.php
@@ -38,6 +38,8 @@ class PayPalExpressCheckout extends PaymentMethod
 
     public function startPayment(Cart $cart, float $amount, string $currency)
     {
+        $amount = number_format($amount, 2);
+
         $payment = $this->createPayment($cart, $amount, $currency);
 
         $items = $cart->content()->map(function (CartItem $cartItem) use ($currency) {

--- a/src/Payment/Method/PayPalExpressCheckout.php
+++ b/src/Payment/Method/PayPalExpressCheckout.php
@@ -38,8 +38,6 @@ class PayPalExpressCheckout extends PaymentMethod
 
     public function startPayment(Cart $cart, float $amount, string $currency)
     {
-        $amount = number_format($amount, 2);
-
         $payment = $this->createPayment($cart, $amount, $currency);
 
         $items = $cart->content()->map(function (CartItem $cartItem) use ($currency) {


### PR DESCRIPTION
`[2022-07-23 14:04:43] production.ERROR: {"name":"UNPROCESSABLE_ENTITY","details":[{"field":"/purchase_units/@reference_id=='default'/amount/value","value":"29.979999999999997","issue":"DECIMAL_PRECISION","description":"If the currency supports decimals, only two decimal place precision is supported."}],"message":"The requested action could not be performed, semantically incorrect, or failed business validation.","debug_id":"1756e2e4f00c7","links":[{"href":"https://developer.paypal.com/docs/api/orders/v2/#error-DECIMAL_PRECISION%22,%22rel%22:%22information_link%22,%22method%22:%22GET%22%7D]%7D {"userId":1,"exception":"[object] (PayPalHttp\HttpException(code: 0): {"name":"UNPROCESSABLE_ENTITY","details":[{"field":"/purchase_units/@reference_id=='default'/amount/value","value":"29.979999999999997","issue":"DECIMAL_PRECISION","description":"If the currency supports decimals, only two decimal place precision is supported."}],"message":"The requested action could not be performed, semantically incorrect, or failed business validation.","debug_id":"1756e2e4f00c7","links":[{"href":"https://developer.paypal.com/docs/api/orders/v2/#error-DECIMAL_PRECISION%5C%22,%5C%22rel%5C%22:%5C%22information_link%5C%22,%5C%22method%5C%22:%5C%22GET%5C%22%7D]%7D at /var/www/oneblock/plugins/shop/vendor/paypal/paypalhttp/lib/PayPalHttp/HttpClient.php:222)
[stacktrace]`

**Reproduction:**
Put two items with decimals like 4.99 and 24.99 in a basket! Pay with paypal express and you will get an error before the paypal redirection.