### PR TITLE
Modification "Vos achats"

### DIFF
--- a/resources/views/admin/payments/index.blade.php
+++ b/resources/views/admin/payments/index.blade.php
@@ -51,7 +51,7 @@
                                     {{ trans('shop::admin.payments.status.'.$payment->status) }}
                                 </span>
                             </td>
-                            <td>{{ $payment->transaction_id ?? trans('messages.unknown') }}</td>
+                            <td>{{ $payment->transaction_id ?? trans( $payment->id ) }}</td>
                             <td>{{ format_date_compact($payment->created_at) }}</td>
                             <td>
                                 <a href="{{ route('shop.admin.payments.show', $payment) }}" class="mx-1" title="{{ trans('messages.actions.show') }}" data-bs-toggle="tooltip"><i class="bi bi-eye"></i></a>

--- a/resources/views/admin/payments/show.blade.php
+++ b/resources/views/admin/payments/show.blade.php
@@ -22,7 +22,7 @@
                                     {{ trans('shop::admin.payments.status.'.$payment->status) }}
                                 </span>
                             </li>
-                            <li>{{ trans('shop::messages.fields.payment_id') }}: {{ $payment->transaction_id ?? trans('messages.unknown') }}</li>
+                            <li>{{ trans('shop::messages.fields.payment_id') }}: {{ $payment->transaction_id ?? trans( $payment->id ) }}</li>
                         @else
                             <li>{{ trans('shop::messages.fields.price') }}: {{ format_money($payment->price) }}</li>
                         @endif

--- a/resources/views/profile/index.blade.php
+++ b/resources/views/profile/index.blade.php
@@ -31,7 +31,7 @@
                                 {{ trans('shop::admin.payments.status.'.$payment->status) }}
                             </span>
                             </td>
-                            <td>{{ $payment->transaction_id ?? trans('messages.unknown') }}</td>
+                            <td>{{ $payment->transaction_id ?? trans( $payment->id ) }}</td>
                             <td>{{ format_date_compact($payment->created_at) }}</td>
                         </tr>
                     @endforeach

--- a/src/Payment/PaymentManager.php
+++ b/src/Payment/PaymentManager.php
@@ -81,13 +81,14 @@ class PaymentManager
         $this->paymentMethods->put($id, $method);
     }
 
-    public function buyPackages(Cart $cart)
+    public function buyPackages(Cart $cart, string $paymentId = null)
     {
         $payment = Payment::create([
             'price' => $cart->total(),
-            'gateway_type' => 'azuriom',
+            'gateway_type' => money_name(),
             'status' => 'completed',
-            'currency' => 'XXX',
+            'currency' => '',
+            'transaction_id' => $paymentId,
         ]);
 
         foreach ($cart->content() as $cartItem) {


### PR DESCRIPTION
Bonsoir,

J'ai modifié plusieurs choses qui touchent à la page Paiements du plugin Shop.

Exemple d'avant: #: 74 Prix: 10 XXX Type: azuriom ID du Paiement: Inconnu(e)
Exemple de maintenant: #: 74 Prix: 10 Type: points ID du Paiement: 74

Quand un achat était effectué avec l'argent du site dans Type c'était écrit "azuriom" j'ai donc remplacé par le nom de la monnaie du site.
Plusieurs moyens de paiement et les achats avec la monnaie du site retournaient un ID de Paiement inconnu, j'ai préféré mettre le même que celui qu'on peut retrouver sur le "#" ça fait beaucoup moins fouillis.

 
