### PR TITLE
Add missing Stripe option for WeChat Pay

### DIFF
--- a/src/Payment/Method/StripeMethod.php
+++ b/src/Payment/Method/StripeMethod.php
@@ -85,12 +85,11 @@ class StripeMethod extends PaymentMethod
             ];
         }
         
-         if (in_array('wechat_pay', $methods, true)) {
-          $params['payment_method_options']['wechat_pay'] = [
+        if (in_array('wechat_pay', $methods, true)) {
+            $params['payment_method_options']['wechat_pay'] = [
                 'client' => 'web'
             ];
         }
-
 
         $session = Session::create($params);
 

--- a/src/Payment/Method/StripeMethod.php
+++ b/src/Payment/Method/StripeMethod.php
@@ -84,10 +84,10 @@ class StripeMethod extends PaymentMethod
                 'allowed_countries' => ['AU', 'CA', 'GB', 'FR', 'NZ', 'UK', 'US'],
             ];
         }
-        
+
         if (in_array('wechat_pay', $methods, true)) {
             $params['payment_method_options']['wechat_pay'] = [
-                'client' => 'web'
+                'client' => 'web',
             ];
         }
 

--- a/src/Payment/Method/StripeMethod.php
+++ b/src/Payment/Method/StripeMethod.php
@@ -84,6 +84,13 @@ class StripeMethod extends PaymentMethod
                 'allowed_countries' => ['AU', 'CA', 'GB', 'FR', 'NZ', 'UK', 'US'],
             ];
         }
+        
+         if (in_array('wechat_pay', $methods, true)) {
+          $params['payment_method_options']['wechat_pay'] = [
+                'client' => 'web'
+            ];
+        }
+
 
         $session = Session::create($params);
 


### PR DESCRIPTION
When using wechat_pay method, the parameter [payment_method_options][wechat_pay][client] is required. The documentation suggests the client parameter has to be fixed as web.

![Capture2](https://user-images.githubusercontent.com/15892444/211804002-99bdde4f-b63a-45f4-9c69-804bd44ce92d.PNG)
