### PR TITLE
fix `originalTotal` behaviour in `Cart` class

### DIFF
--- a/src/Cart/Cart.php
+++ b/src/Cart/Cart.php
@@ -202,7 +202,7 @@ class Cart implements Arrayable
      */
     public function originalTotal()
     {
-        return $this->content()->sum(fn (CartItem $item) => $item->total());
+        return $this->content()->sum(fn (CartItem $item) => $item->originalTotal());
     }
 
     /**


### PR DESCRIPTION
This isn't actually used by the plugin, just fixes the method implementation for other eventual users.