### PR TITLE
add paypal main email warning

### DIFF
--- a/resources/lang/en/admin.php
+++ b/resources/lang/en/admin.php
@@ -119,6 +119,7 @@ return [
         'methods-info' => 'Credit cards are enabled by default. You can find more information in the <a href=":docs">Stripe documentation</a>.',
 
         'paypal_email' => 'PayPal Email Address',
+        'paypal_info' => 'Please make sure to input the main email address of the PayPal account. If not, it WILL make payments fail.',
         'paysafecard_info' => 'In order to be able to accept payments by paysafecard, you must be a <a href="https://www.paysafecard.com/en/business/" target="_blank" rel="noopener noreferrer">paysafecard partner</a>. Other methods exist but only this one is allowed by paysafecard.',
         'stripe_info' => 'On the Stripe dashboard you need to set the webhook URL to <code>:url</code> and select the event <code>checkout.session.completed</code>.',
         'paymentwall_info' => 'On the PaymentWall dashboard you need to set the pingback URL to <code>:url</code>.',

--- a/resources/lang/en/admin.php
+++ b/resources/lang/en/admin.php
@@ -119,7 +119,7 @@ return [
         'methods-info' => 'Credit cards are enabled by default. You can find more information in the <a href=":docs">Stripe documentation</a>.',
 
         'paypal_email' => 'PayPal Email Address',
-        'paypal_info' => 'Please make sure to input the main email address of the PayPal account. If not, it WILL make payments fail.',
+        'paypal_info' => 'Please make sure to input the <strong>main</strong> email address of the PayPal account.',
         'paysafecard_info' => 'In order to be able to accept payments by paysafecard, you must be a <a href="https://www.paysafecard.com/en/business/" target="_blank" rel="noopener noreferrer">paysafecard partner</a>. Other methods exist but only this one is allowed by paysafecard.',
         'stripe_info' => 'On the Stripe dashboard you need to set the webhook URL to <code>:url</code> and select the event <code>checkout.session.completed</code>.',
         'paymentwall_info' => 'On the PaymentWall dashboard you need to set the pingback URL to <code>:url</code>.',

--- a/resources/lang/fr/admin.php
+++ b/resources/lang/fr/admin.php
@@ -119,6 +119,7 @@ return [
         'methods-info' => 'Les cartes bancaires sont supportées par défaut. Vous pouvez avoir plus d\'informations dans la <a href=":docs">documentation Stripe</a>.',
 
         'paypal_email' => 'Adresse Email PayPal',
+        'paypal_info' => 'Assurez vous d\'indiquer l\'adresse e-mail principale du compte PayPal. Sinon, les paiements ÉCHOUERONT.',
         'paysafecard_info' => 'Pour pouvoir accepter les paiements par paysafecard, vous devez être un <a href="https://www.paysafecard.com/fr/entreprises/" target="_blank" rel="noopener noreferrer">partenaire paysafecard</a>. D\'autres méthodes existent, mais celle-ci est la seule autorisée par paysafecard.',
         'stripe_info' => 'Sur le tableau de bord Stripe, vous devez définir l\'URL du webhook sur <code>:url</code> et séléctionner l\'événement <code>checkout.session.completed</code>.',
         'paymentwall_info' => 'Dans le tableau de bord PaymentWall, vous devez définir l\'URL de pingback sur <code>:url</code>.',

--- a/resources/lang/fr/admin.php
+++ b/resources/lang/fr/admin.php
@@ -119,7 +119,7 @@ return [
         'methods-info' => 'Les cartes bancaires sont supportées par défaut. Vous pouvez avoir plus d\'informations dans la <a href=":docs">documentation Stripe</a>.',
 
         'paypal_email' => 'Adresse Email PayPal',
-        'paypal_info' => 'Assurez vous d\'indiquer l\'adresse e-mail principale du compte PayPal. Sinon, les paiements ÉCHOUERONT.',
+        'paypal_info' => 'Assurez vous d\'indiquer l\'adresse e-mail <strong>principale</strong> du compte PayPal.',
         'paysafecard_info' => 'Pour pouvoir accepter les paiements par paysafecard, vous devez être un <a href="https://www.paysafecard.com/fr/entreprises/" target="_blank" rel="noopener noreferrer">partenaire paysafecard</a>. D\'autres méthodes existent, mais celle-ci est la seule autorisée par paysafecard.',
         'stripe_info' => 'Sur le tableau de bord Stripe, vous devez définir l\'URL du webhook sur <code>:url</code> et séléctionner l\'événement <code>checkout.session.completed</code>.',
         'paymentwall_info' => 'Dans le tableau de bord PaymentWall, vous devez définir l\'URL de pingback sur <code>:url</code>.',

--- a/resources/views/admin/gateways/methods/paypal.blade.php
+++ b/resources/views/admin/gateways/methods/paypal.blade.php
@@ -6,3 +6,7 @@
     <span class="invalid-feedback" role="alert"><strong>{{ $message }}</strong></span>
     @enderror
 </div>
+
+<div class="alert alert-info" role="alert">
+    <i class="bi bi-info-circle"></i> @lang('shop::admin.gateways.paypal_info')
+</div>


### PR DESCRIPTION
Multiple email addresses can be added to the same PayPal account and used to receive payments. PayPal IPN (Instant Payment Notifications) only include the *main* email address associated with the account which can cause the payments to be marked as failed in  [PayPalMethod.php#L105-L109](https://github.com/ArnaudLier/Plugin-Shop/blob/ffab3eacf332a4c1a0c696a066874ff7d34a2c41/src/Payment/Method/PayPalMethod.php#L105-L109)