### PR TITLE
Feature: Toggle usage of gift cards via settings

### DIFF
--- a/resources/lang/en/admin.php
+++ b/resources/lang/en/admin.php
@@ -179,6 +179,7 @@ return [
         'recent_payments' => 'Recent payments limit to display in sidebar (set to 0 to disable)',
         'display_amount' => 'Display amount spend in recent payments and top customer',
         'top_customer' => 'Display top monthly customer in sidebar',
+        'enable_gift_cards' => 'Enable gift cards',
     ],
 
     'logs' => [

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -129,4 +129,8 @@ return [
         'add' => 'Add a gift card',
         'notification' => 'You received a giftcard, the code is :code (:balance).',
     ],
+
+    'exceptions' => [
+        'feature_disabled_settings' => 'This feature has been disabled via the settings',
+    ],
 ];

--- a/resources/views/admin/settings.blade.php
+++ b/resources/views/admin/settings.blade.php
@@ -29,6 +29,13 @@
                     <small id="moneyLabel" class="form-text">{{ trans('shop::admin.settings.use_site_money_info') }}</small>
                 </div>
 
+                <div class="mb-3">
+                    <div class="form-check form-switch">
+                        <input type="checkbox" class="form-check-input" id="enableGiftCards" name="enable_gift_cards" @checked($enableGiftCards)>
+                        <label class="form-check-label" for="enableGiftCards">{{ trans('shop::admin.settings.enable_gift_cards') }}</label>
+                    </div>
+                </div>
+
                 <div class="mb-3 form-check form-switch">
                     <input type="checkbox" class="form-check-input" id="homeSwitch" name="enable_home" data-bs-toggle="collapse" data-bs-target="#homeMessage" @checked($enableHome)>
                     <label class="form-check-label" for="homeSwitch">{{ trans('shop::admin.settings.enable_home') }}</label>

--- a/resources/views/cart/index.blade.php
+++ b/resources/views/cart/index.blade.php
@@ -130,6 +130,7 @@
                     {{ trans('shop::messages.cart.total', ['total' => shop_format_amount($cart->total())]) }}
                 </h5>
 
+            @if (setting('shop.enable_gift_cards', true))
                 <div class="row">
                     <div class="col-md-4">
                         <h5>{{ trans('shop::messages.giftcards.add') }}</h5>
@@ -190,6 +191,7 @@
                         </div>
                     @endif
                 </div>
+            @endif
 
                 <div class="row">
                     <div class="col-md-6">

--- a/resources/views/profile/index.blade.php
+++ b/resources/views/profile/index.blade.php
@@ -42,25 +42,27 @@
         </div>
     </div>
 
-    <div class="card">
-        <div class="card-body">
-            <h2 class="card-title">{{ trans('shop::messages.giftcards.add') }}</h2>
+    @if (setting('shop.enable_gift_cards', true))
+        <div class="card">
+            <div class="card-body">
+                <h2 class="card-title">{{ trans('shop::messages.giftcards.add') }}</h2>
 
-            <form action="{{ route('shop.giftcards.add') }}" method="POST">
-                @csrf
+                <form action="{{ route('shop.giftcards.add') }}" method="POST">
+                    @csrf
 
-                <div class="mb-3">
-                    <input type="text" class="form-control @error('code') is-invalid @enderror" placeholder="{{ trans('shop::messages.fields.code') }}" id="code" name="code" value="{{ old('code') }}">
+                    <div class="mb-3">
+                        <input type="text" class="form-control @error('code') is-invalid @enderror" placeholder="{{ trans('shop::messages.fields.code') }}" id="code" name="code" value="{{ old('code') }}">
 
-                    @error('code')
-                    <span class="invalid-feedback" role="alert"><strong>{{ $message }}</strong></span>
-                    @enderror
-                </div>
+                        @error('code')
+                        <span class="invalid-feedback" role="alert"><strong>{{ $message }}</strong></span>
+                        @enderror
+                    </div>
 
-                <button type="submit" class="btn btn-primary">
-                    {{ trans('messages.actions.send') }}
-                </button>
-            </form>
+                    <button type="submit" class="btn btn-primary">
+                        {{ trans('messages.actions.send') }}
+                    </button>
+                </form>
+            </div>
         </div>
-    </div>
+    @endif
 @endsection

--- a/src/Controllers/Admin/SettingController.php
+++ b/src/Controllers/Admin/SettingController.php
@@ -32,6 +32,7 @@ class SettingController extends Controller
             'servers' => Server::executable()->get(),
             'enableHome' => setting('shop.home.enabled', true),
             'homeMessage' => setting('shop.home', ''),
+            'enableGiftCards' => setting('shop.enable_gift_cards', true),
         ]);
     }
 
@@ -63,6 +64,7 @@ class SettingController extends Controller
             'shop.home' => $request->input('home_message'),
             'shop.home.enabled' => $request->has('enable_home'),
             'shop.commands' => is_array($commands) ? json_encode($commands) : null,
+            'shop.enable_gift_cards' => $request->has('enable_gift_cards'),
         ]);
 
         return to_route('shop.admin.settings')

--- a/src/Controllers/GiftcardController.php
+++ b/src/Controllers/GiftcardController.php
@@ -5,6 +5,7 @@ namespace Azuriom\Plugin\Shop\Controllers;
 use Azuriom\Http\Controllers\Controller;
 use Azuriom\Models\ActionLog;
 use Azuriom\Plugin\Shop\Cart\Cart;
+use Azuriom\Plugin\Shop\Exceptions\FeatureNotEnabledException;
 use Azuriom\Plugin\Shop\Models\Giftcard;
 use Illuminate\Http\Request;
 use Illuminate\Validation\ValidationException;
@@ -18,6 +19,10 @@ class GiftcardController extends Controller
      */
     public function add(Request $request)
     {
+        if (! $this->hasGiftCardsEnabled()) {
+            throw new FeatureNotEnabledException();
+        }
+
         $validated = $this->validate($request, ['code' => 'required']);
 
         $giftcard = Giftcard::active()->firstWhere($validated);
@@ -38,6 +43,10 @@ class GiftcardController extends Controller
      */
     public function remove(Request $request, Giftcard $giftcard)
     {
+        if (! $this->hasGiftCardsEnabled()) {
+            throw new FeatureNotEnabledException();
+        }
+
         Cart::fromSession($request->session())->removeGiftcard($giftcard);
 
         return to_route('shop.cart.index');
@@ -50,6 +59,10 @@ class GiftcardController extends Controller
      */
     public function use(Request $request)
     {
+        if (! $this->hasGiftCardsEnabled()) {
+            throw new FeatureNotEnabledException();
+        }
+
         $validated = $this->validate($request, ['code' => 'required']);
 
         $giftcard = Giftcard::active()->firstWhere($validated);
@@ -73,5 +86,10 @@ class GiftcardController extends Controller
         return redirect()->back()->with('success', trans('shop::messages.giftcards.success', [
             'money' => format_money($amount),
         ]));
+    }
+
+    private function hasGiftCardsEnabled(): bool
+    {
+        return setting('shop.enable_gift_cards', true);
     }
 }

--- a/src/Exceptions/FeatureNotEnabledException.php
+++ b/src/Exceptions/FeatureNotEnabledException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Azuriom\Plugin\Shop\Exceptions;
+
+use Exception;
+
+class FeatureNotEnabledException extends Exception
+{
+    public function __construct()
+    {
+        parent::__construct(trans('Shop::messages.exceptions.feature_disabled_settings'));
+    }
+}

--- a/src/Models/Giftcard.php
+++ b/src/Models/Giftcard.php
@@ -67,6 +67,10 @@ class Giftcard extends Model
 
     public function notifyUser(User $user): void
     {
+        if (! setting('shop.enable_gift_cards', true)) {
+            return;
+        }
+
         (new AlertNotification(trans('shop::messages.giftcards.notification', [
             'balance' => shop_format_amount($this->balance),
             'code' => $this->code,


### PR DESCRIPTION
Make it possible to enable or disable the usage of gift cards throughout the shop via the settings.

Closes: feature/toggle-usage-of-giftcards

Note: this does keep the giftcard elements available for the admin, its pointed towards user interactions / notifications.