### PR TITLE
Feature: Toggle usage of coupons via settings

### DIFF
--- a/resources/lang/en/admin.php
+++ b/resources/lang/en/admin.php
@@ -179,6 +179,7 @@ return [
         'recent_payments' => 'Recent payments limit to display in sidebar (set to 0 to disable)',
         'display_amount' => 'Display amount spend in recent payments and top customer',
         'top_customer' => 'Display top monthly customer in sidebar',
+        'enable_coupons' => 'Enable coupons',
     ],
 
     'logs' => [

--- a/resources/views/admin/settings.blade.php
+++ b/resources/views/admin/settings.blade.php
@@ -29,6 +29,13 @@
                     <small id="moneyLabel" class="form-text">{{ trans('shop::admin.settings.use_site_money_info') }}</small>
                 </div>
 
+                <div class="mb-3">
+                    <div class="form-check form-switch">
+                        <input type="checkbox" class="form-check-input" id="enableCoupons" name="enable_coupons" @checked($enableCoupons)>
+                        <label class="form-check-label" for="enableCoupons">{{ trans('shop::admin.settings.enable_coupons') }}</label>
+                    </div>
+                </div>
+
                 <div class="mb-3 form-check form-switch">
                     <input type="checkbox" class="form-check-input" id="homeSwitch" name="enable_home" data-bs-toggle="collapse" data-bs-target="#homeMessage" @checked($enableHome)>
                     <label class="form-check-label" for="homeSwitch">{{ trans('shop::admin.settings.enable_home') }}</label>

--- a/resources/views/cart/index.blade.php
+++ b/resources/views/cart/index.blade.php
@@ -69,6 +69,7 @@
                     </button>
                 </form>
 
+            @if (setting('shop.enable_coupons', true))
                 <div class="row">
                     <div class="col-md-4">
                         <h5>{{ trans('shop::messages.coupons.add') }}</h5>
@@ -125,6 +126,7 @@
                         </div>
                     @endif
                 </div>
+            @endif
 
                 <h5 class="text-end">
                     {{ trans('shop::messages.cart.total', ['total' => shop_format_amount($cart->total())]) }}

--- a/src/Controllers/Admin/SettingController.php
+++ b/src/Controllers/Admin/SettingController.php
@@ -32,6 +32,7 @@ class SettingController extends Controller
             'servers' => Server::executable()->get(),
             'enableHome' => setting('shop.home.enabled', true),
             'homeMessage' => setting('shop.home', ''),
+            'enableCoupons' => setting('shop.enable_coupons', true),
         ]);
     }
 
@@ -63,6 +64,7 @@ class SettingController extends Controller
             'shop.home' => $request->input('home_message'),
             'shop.home.enabled' => $request->has('enable_home'),
             'shop.commands' => is_array($commands) ? json_encode($commands) : null,
+            'shop.enable_coupons' => $request->has('enable_coupons'),
         ]);
 
         return to_route('shop.admin.settings')


### PR DESCRIPTION
Make it possible to enable or disable the usage of coupons throughout the shop via the settings.

Closes: feature/toggle-usage-of-coupons

Note: this does keep the coupon elements available for the admin, its pointed towards user interactions and cart calculations.