### PR TITLE
Feature: Toggle interaction limitations on coupons and discounts

### DIFF
--- a/database/migrations/2024_02_25_000000_add_shop_coupons_can_be_redeemed_with_discounts.php
+++ b/database/migrations/2024_02_25_000000_add_shop_coupons_can_be_redeemed_with_discounts.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('shop_coupons', function (Blueprint $table) {
+            $table->boolean('discount_allowed')->default(true)->after('can_cumulate');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('shop_coupons', function (Blueprint $table) {
+            $table->dropColumn('discount_allowed');
+        });
+    }
+};

--- a/database/migrations/2024_02_25_000001_add_shop_discounts_allows_coupons.php
+++ b/database/migrations/2024_02_25_000001_add_shop_discounts_allows_coupons.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('shop_discounts', function (Blueprint $table) {
+            $table->boolean('coupons_allowed')->default(true)->after('discount');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('shop_discounts', function (Blueprint $table) {
+            $table->dropColumn('coupons_allowed');
+        });
+    }
+};

--- a/resources/lang/en/admin.php
+++ b/resources/lang/en/admin.php
@@ -52,6 +52,7 @@ return [
         'active' => 'Active',
         'usage' => 'Under usage limit',
         'enable' => 'Enable the coupon',
+        'discount' => 'Allow usage of discounts with coupon',
     ],
 
     'giftcards' => [
@@ -72,6 +73,7 @@ return [
         'global' => 'Should the discount be active on all the shop ?',
         'active' => 'Active',
         'enable' => 'Enable the discount',
+        'coupons' => 'Allow usage of coupons with discount',
     ],
 
     'packages' => [

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -84,6 +84,7 @@ return [
         'add' => 'Add a coupon',
         'error' => 'This coupon does not exist, has expired or can no longer be used.',
         'cumulate' => 'You cannot use this coupon with an other coupon.',
+        'discount' => 'You cannot use this coupon with one or more of the existing discounts applied.',
     ],
 
     'payment' => [

--- a/resources/views/admin/coupons/_form.blade.php
+++ b/resources/views/admin/coupons/_form.blade.php
@@ -116,3 +116,8 @@
     <input type="checkbox" class="form-check-input" id="enableSwitch" name="is_enabled" @checked($coupon->is_enabled ?? true)>
     <label class="form-check-label" for="enableSwitch">{{ trans('shop::admin.coupons.enable') }}</label>
 </div>
+
+<div class="mb-3 form-check form-switch">
+    <input type="checkbox" class="form-check-input" id="discountSwitch" name="discount_allowed" @checked($coupon->discount_allowed ?? true)>
+    <label class="form-check-label" for="discountSwitch">{{ trans('shop::admin.coupons.discount') }}</label>
+</div>

--- a/resources/views/admin/discounts/_form.blade.php
+++ b/resources/views/admin/discounts/_form.blade.php
@@ -77,3 +77,8 @@
     <input type="checkbox" class="form-check-input" id="enableSwitch" name="is_enabled" @checked($discount->is_enabled ?? true)>
     <label class="form-check-label" for="enableSwitch">{{ trans('shop::admin.discounts.enable') }}</label>
 </div>
+
+<div class="mb-3 form-check form-switch">
+    <input type="checkbox" class="form-check-input" id="allowCouponsSwitch" name="coupons_allowed" @checked($discount->coupons_allowed ?? true)>
+    <label class="form-check-label" for="allowCouponsSwitch">{{ trans('shop::admin.discounts.coupons') }}</label>
+</div>

--- a/resources/views/cart/index.blade.php
+++ b/resources/views/cart/index.blade.php
@@ -76,14 +76,14 @@
                         <form action="{{ route('shop.cart.coupons.add') }}" method="POST" >
                             @csrf
 
-                            <div class="input-group mb-3 @error('code') has-validation @enderror">
-                                <input type="text" class="form-control @error('code') is-invalid @enderror" placeholder="{{ trans('shop::messages.fields.code') }}" id="code" name="code" value="{{ old('code') }}">
+                            <div class="input-group mb-3 @error('coupon_code') has-validation @enderror">
+                                <input type="text" class="form-control @error('coupon_code') is-invalid @enderror" placeholder="{{ trans('shop::messages.fields.code') }}" id="coupon_code" name="coupon_code" value="{{ old('coupon_code') }}">
 
                                 <button type="submit" class="btn btn-primary">
                                     <i class="bi bi-plus-lg"></i> {{ trans('messages.actions.add') }}
                                 </button>
 
-                                @error('code')
+                                @error('coupon_code')
                                 <span class="invalid-feedback" role="alert"><strong>{{ $message }}</strong></span>
                                 @enderror
                             </div>

--- a/src/Exceptions/CouponNotAllowedException.php
+++ b/src/Exceptions/CouponNotAllowedException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Azuriom\Plugin\Shop\Exceptions;
+
+use Exception;
+
+final class CouponNotAllowedException extends Exception
+{
+}

--- a/src/Models/Coupon.php
+++ b/src/Models/Coupon.php
@@ -14,6 +14,7 @@ use Illuminate\Database\Eloquent\Model;
  * @property int $user_limit
  * @property int $global_limit
  * @property bool $can_cumulate
+ * @property bool $discount_allowed
  * @property bool $is_enabled
  * @property bool $is_global
  * @property bool $is_fixed
@@ -42,7 +43,7 @@ class Coupon extends Model
      * @var array<int, string>
      */
     protected $fillable = [
-        'code', 'discount', 'start_at', 'expire_at', 'user_limit', 'global_limit', 'can_cumulate', 'is_enabled', 'is_global', 'is_fixed',
+        'code', 'discount', 'start_at', 'expire_at', 'user_limit', 'global_limit', 'can_cumulate', 'is_enabled', 'is_global', 'is_fixed', 'discount_allowed',
     ];
 
     /**
@@ -57,6 +58,7 @@ class Coupon extends Model
         'is_enabled' => 'boolean',
         'is_global' => 'boolean',
         'is_fixed' => 'boolean',
+        'discount_allowed' => 'boolean',
     ];
 
     /**

--- a/src/Models/Discount.php
+++ b/src/Models/Discount.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Model;
  * @property int $id
  * @property string $name
  * @property int $discount
+ * @property bool $coupons_allowed
  * @property bool $is_global
  * @property bool $is_enabled
  * @property \Carbon\Carbon $start_at
@@ -37,7 +38,7 @@ class Discount extends Model
      * @var array<int, string>
      */
     protected $fillable = [
-        'name', 'discount', 'packages', 'is_global', 'is_enabled', 'start_at', 'end_at',
+        'name', 'discount', 'packages', 'is_global', 'is_enabled', 'start_at', 'end_at', 'coupons_allowed',
     ];
 
     /**
@@ -50,6 +51,7 @@ class Discount extends Model
         'end_at' => 'datetime',
         'is_global' => 'boolean',
         'is_enabled' => 'boolean',
+        'coupons_allowed' => 'boolean',
     ];
 
     /**

--- a/src/Requests/CouponRequest.php
+++ b/src/Requests/CouponRequest.php
@@ -18,7 +18,7 @@ class CouponRequest extends FormRequest
      * @var array<int, string>
      */
     protected array $checkboxes = [
-        'can_cumulate', 'is_enabled', 'is_global',
+        'can_cumulate', 'is_enabled', 'is_global', 'discount_allowed',
     ];
 
     /**
@@ -50,6 +50,7 @@ class CouponRequest extends FormRequest
             'is_enabled' => ['filled', 'boolean'],
             'is_global' => ['filled', 'boolean'],
             'is_fixed' => ['filled', 'boolean'],
+            'discount_allowed' => ['filled', 'boolean'],
         ];
     }
 }

--- a/src/Requests/DiscountRequest.php
+++ b/src/Requests/DiscountRequest.php
@@ -15,7 +15,7 @@ class DiscountRequest extends FormRequest
      * @var array<int, string>
      */
     protected array $checkboxes = [
-        'is_global', 'is_enabled',
+        'is_global', 'is_enabled', 'coupons_allowed',
     ];
 
     /**
@@ -33,6 +33,7 @@ class DiscountRequest extends FormRequest
             'end_at' => ['required', 'date', 'after:start_at'],
             'is_global' => ['filled', 'boolean'],
             'is_enabled' => ['filled', 'boolean'],
+            'coupons_allowed' => ['filled', 'boolean'],
         ];
     }
 }


### PR DESCRIPTION
This feature allows customization of the interaction between coupons and discounts that are applied to the cart of the user. Discounts can disallow usage of coupons and vice versa.

Also added in this feature is a fix for the validation exception response in the cart, this would show the error message related to "code" to both coupons add input field and the gift card add input field.

Closes: feature/coupon-and-discount-interaction-limitations