### PR TITLE
Fix profile translation-key action in subscription payment mail

### DIFF
--- a/src/Notifications/PaymentPaid.php
+++ b/src/Notifications/PaymentPaid.php
@@ -47,7 +47,7 @@ class PaymentPaid extends Notification
 
                 $message->line(trans('shop::mails.payment.subscription', [
                     'date' => format_date($subscription->created_at, true),
-                ]))->action(trans('shop::mails.payment.subscription'), route('shop.profile'));
+                ]))->action(trans('shop::mails.payment.profile'), route('shop.profile'));
             });
     }
 


### PR DESCRIPTION
Action button in subscription payment mail notification was using the wrong translation key.