### PR TITLE
Fix purchase message not showing for subcategories due to redirection

### DIFF
--- a/src/Controllers/CategoryController.php
+++ b/src/Controllers/CategoryController.php
@@ -64,7 +64,7 @@ class CategoryController extends Controller
     /**
      * Display the specified resource.
      */
-    public function show(Category $category, Request $request)
+    public function show(Request $request, Category $category)
     {
         $categories = $this->getCategories();
 
@@ -73,7 +73,8 @@ class CategoryController extends Controller
         }]);
 
         if ($category->packages->isEmpty() && ! $category->categories->isEmpty()) {
-            $request->session()->reflash();
+            $request->session()->reflash(); // Keep status messages after redirection
+
             return to_route('shop.categories.show', $category->categories->first());
         }
 

--- a/src/Controllers/CategoryController.php
+++ b/src/Controllers/CategoryController.php
@@ -73,15 +73,8 @@ class CategoryController extends Controller
         }]);
 
         if ($category->packages->isEmpty() && ! $category->categories->isEmpty()) {
-            $redirect = to_route('shop.categories.show', $category->categories->first());
-            
-            foreach (['success', 'error', 'warning', 'info'] as $type) {
-                if ($request->session()->has($type)) {
-                    $redirect = $redirect->with($type, $request->session()->get($type));
-                }
-            }
-            
-            return $redirect;
+            $request->session()->reflash();
+            return to_route('shop.categories.show', $category->categories->first());
         }
 
         return view('shop::categories.show', [

--- a/src/Controllers/CategoryController.php
+++ b/src/Controllers/CategoryController.php
@@ -64,7 +64,7 @@ class CategoryController extends Controller
     /**
      * Display the specified resource.
      */
-    public function show(Category $category)
+    public function show(Category $category, Request $request)
     {
         $categories = $this->getCategories();
 
@@ -73,7 +73,15 @@ class CategoryController extends Controller
         }]);
 
         if ($category->packages->isEmpty() && ! $category->categories->isEmpty()) {
-            return to_route('shop.categories.show', $category->categories->first());
+            $redirect = to_route('shop.categories.show', $category->categories->first());
+            
+            foreach (['success', 'error', 'warning', 'info'] as $type) {
+                if ($request->session()->has($type)) {
+                    $redirect = $redirect->with($type, $request->session()->get($type));
+                }
+            }
+            
+            return $redirect;
         }
 
         return view('shop::categories.show', [


### PR DESCRIPTION
This fixes the issue where, when there are subcategories, the purchase message was not displayed due to a redirection.