### PR TITLE
Remove invoice creation from StripeMethod

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
     "id": "shop",
     "name": "Shop",
     "description": "A shop plugin to sell in-game items on your website.",
-    "version": "1.2.19",
+    "version": "1.2.20",
     "url": "https://market.azuriom.com/resources/1",
     "authors": [
         "Azuriom"

--- a/src/Payment/Method/StripeMethod.php
+++ b/src/Payment/Method/StripeMethod.php
@@ -111,9 +111,6 @@ class StripeMethod extends PaymentMethod
             'success_url' => str_replace('%id%', '{CHECKOUT_SESSION_ID}', $successUrl),
             'cancel_url' => route('shop.categories.show', $package->category),
             'metadata' => ['user' => $user->id, 'package' => $package->id],
-            'invoice_creation' => [
-                'enabled' => $this->gateway->data['invoice'] ?? false,
-            ],
         ]);
 
         return redirect()->away($session->url);


### PR DESCRIPTION
Removed invoice creation from Stripe session parameters during subscriptions as Stripe doesn't support it.

The error was: `You can only enable invoice creation when mode is set to payment. Invoices are created automatically when mode is set to subscription, and are unsupported when set to setup. To learn more visit https://stripe.com/docs/payments/checkout/post-payment-invoices.`