### PR TITLE
fix(stripe): cast invoice_creation enabled to boolean

### DIFF
--- a/src/Payment/Method/StripeMethod.php
+++ b/src/Payment/Method/StripeMethod.php
@@ -74,7 +74,7 @@ class StripeMethod extends PaymentMethod
             'client_reference_id' => $payment->id,
             'discounts' => $coupon ? [['coupon' => $coupon->id]] : [],
             'invoice_creation' => [
-                'enabled' => 'enabled' => (bool) ($this->gateway->data['invoice'] ?? false),
+                'enabled' => (bool) ($this->gateway->data['invoice'] ?? false),
             ],
         ]);
 

--- a/src/Payment/Method/StripeMethod.php
+++ b/src/Payment/Method/StripeMethod.php
@@ -74,7 +74,7 @@ class StripeMethod extends PaymentMethod
             'client_reference_id' => $payment->id,
             'discounts' => $coupon ? [['coupon' => $coupon->id]] : [],
             'invoice_creation' => [
-                'enabled' => $this->gateway->data['invoice'] ?? false,
+                'enabled' => 'enabled' => (bool) ($this->gateway->data['invoice'] ?? false),
             ],
         ]);
 


### PR DESCRIPTION
## Description
This PR fixes a `Stripe\Exception\InvalidRequestException` (Invalid boolean: 1) that occurs during the checkout process when the invoice option is enabled.

## Context
In recent versions, the Stripe API has become stricter regarding data types. In `StripeMethod.php`, the value for `invoice_creation['enabled']` was being sent as an integer (`1` or `0`) because of how it's stored in the database, leading to a 400 Bad Request error from Stripe's API.

## Changes
- Added a `(bool)` cast to the `enabled` key in the `invoice_creation` array within the `startPayment` method.
- This ensures a strict boolean (`true`/`false`) is sent to the Stripe SDK.

## Error Log
`production.ERROR: Invalid boolean: 1 {"exception":"[object] (Stripe\\Exception\\InvalidRequestException(code: 0): Invalid boolean: 1 at .../lib/Exception/ApiErrorException.php:38)"}`