### PR TITLE
Bump plugin version from 1.2.20 to 1.2.21

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
     "id": "shop",
     "name": "Shop",
     "description": "A shop plugin to sell in-game items on your website.",
-    "version": "1.2.20",
+    "version": "1.2.21",
     "url": "https://market.azuriom.com/resources/1",
     "authors": [
         "Azuriom"


### PR DESCRIPTION
Hey,
I'm bumping the Shop version to `1.2.21` to include [this commit](https://github.com/Azuriom/Plugin-Shop/commit/75ae037b51181d9e1818be95cbd59169f1c6b65a).
Thanks.