### PR TITLE
fix(stripe): restore subscription handling with stripe-php v19

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "mercadopago/dx-php": "^3.0",
         "mollie/mollie-api-php": "^v3.7.0",
         "paymentwall/paymentwall-php": "^2.2",
-        "stripe/stripe-php": "^v19.0.0",
+        "stripe/stripe-php": "^v20.0.0",
         "xsolla/xsolla-sdk-php": "^4.1"
     },
     "replace": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8aa4abe375066a42d83a4995d3f5de9c",
+    "content-hash": "a4cb8cc439ebf17092eba9f49bfb9c9c",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -510,26 +510,26 @@
         },
         {
             "name": "stripe/stripe-php",
-            "version": "v19.2.0",
+            "version": "v20.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/stripe/stripe-php.git",
-                "reference": "e444fbc524cd3d6583dde2c5b375d26174c54d96"
+                "reference": "7338bd140e641b1f9c7cb602e2de971e14db6b3b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/stripe/stripe-php/zipball/e444fbc524cd3d6583dde2c5b375d26174c54d96",
-                "reference": "e444fbc524cd3d6583dde2c5b375d26174c54d96",
+                "url": "https://api.github.com/repos/stripe/stripe-php/zipball/7338bd140e641b1f9c7cb602e2de971e14db6b3b",
+                "reference": "7338bd140e641b1f9c7cb602e2de971e14db6b3b",
                 "shasum": ""
             },
             "require": {
                 "ext-curl": "*",
                 "ext-json": "*",
                 "ext-mbstring": "*",
-                "php": ">=5.6.0"
+                "php": ">=7.2.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "3.72.0",
+                "friendsofphp/php-cs-fixer": "3.94.0",
                 "phpstan/phpstan": "^1.2",
                 "phpunit/phpunit": "^5.7 || ^9.0"
             },
@@ -540,6 +540,9 @@
                 }
             },
             "autoload": {
+                "files": [
+                    "lib/version_check.php"
+                ],
                 "psr-4": {
                     "Stripe\\": "lib/"
                 }
@@ -563,9 +566,9 @@
             ],
             "support": {
                 "issues": "https://github.com/stripe/stripe-php/issues",
-                "source": "https://github.com/stripe/stripe-php/tree/v19.2.0"
+                "source": "https://github.com/stripe/stripe-php/tree/v20.0.0"
             },
-            "time": "2026-01-16T21:28:14+00:00"
+            "time": "2026-03-26T01:57:48+00:00"
         },
         {
             "name": "xsolla/xsolla-sdk-php",
@@ -634,5 +637,5 @@
         "php": ">=8.0"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "composer/ca-bundle",
-            "version": "1.5.10",
+            "version": "1.5.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "961a5e4056dd2e4a2eedcac7576075947c28bf63"
+                "reference": "68ff39175e8e94a4bb1d259407ce51a6a60f09e6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/961a5e4056dd2e4a2eedcac7576075947c28bf63",
-                "reference": "961a5e4056dd2e4a2eedcac7576075947c28bf63",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/68ff39175e8e94a4bb1d259407ce51a6a60f09e6",
+                "reference": "68ff39175e8e94a4bb1d259407ce51a6a60f09e6",
                 "shasum": ""
             },
             "require": {
@@ -64,7 +64,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/ca-bundle/issues",
-                "source": "https://github.com/composer/ca-bundle/tree/1.5.10"
+                "source": "https://github.com/composer/ca-bundle/tree/1.5.11"
             },
             "funding": [
                 {
@@ -76,20 +76,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-12-08T15:06:51+00:00"
+            "time": "2026-03-30T09:16:10+00:00"
         },
         {
             "name": "mercadopago/dx-php",
-            "version": "3.8.0",
+            "version": "v3.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mercadopago/sdk-php.git",
-                "reference": "98a3f7da2f13d1e85b309441b2e45c07fa312bf4"
+                "reference": "7eeafc66b90ffda3d49dba6d81aeacc43e8621b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mercadopago/sdk-php/zipball/98a3f7da2f13d1e85b309441b2e45c07fa312bf4",
-                "reference": "98a3f7da2f13d1e85b309441b2e45c07fa312bf4",
+                "url": "https://api.github.com/repos/mercadopago/sdk-php/zipball/7eeafc66b90ffda3d49dba6d81aeacc43e8621b4",
+                "reference": "7eeafc66b90ffda3d49dba6d81aeacc43e8621b4",
                 "shasum": ""
             },
             "require": {
@@ -113,22 +113,22 @@
             "description": "Mercado Pago PHP SDK",
             "homepage": "https://github.com/mercadopago/sdk-php",
             "support": {
-                "source": "https://github.com/mercadopago/sdk-php/tree/3.8.0"
+                "source": "https://github.com/mercadopago/sdk-php/tree/v3.9.0"
             },
-            "time": "2025-11-28T14:17:27+00:00"
+            "time": "2026-04-17T17:41:52+00:00"
         },
         {
             "name": "mollie/mollie-api-php",
-            "version": "v3.8.0",
+            "version": "v3.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mollie/mollie-api-php.git",
-                "reference": "4a319d1c779fd9a1108402950482b009e681bb9e"
+                "reference": "ef526b9e4eb0c87e294f275e4f11d07b33e08a34"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mollie/mollie-api-php/zipball/4a319d1c779fd9a1108402950482b009e681bb9e",
-                "reference": "4a319d1c779fd9a1108402950482b009e681bb9e",
+                "url": "https://api.github.com/repos/mollie/mollie-api-php/zipball/ef526b9e4eb0c87e294f275e4f11d07b33e08a34",
+                "reference": "ef526b9e4eb0c87e294f275e4f11d07b33e08a34",
                 "shasum": ""
             },
             "require": {
@@ -209,9 +209,9 @@
             ],
             "support": {
                 "issues": "https://github.com/mollie/mollie-api-php/issues",
-                "source": "https://github.com/mollie/mollie-api-php/tree/v3.8.0"
+                "source": "https://github.com/mollie/mollie-api-php/tree/v3.10.0"
             },
-            "time": "2026-01-06T18:53:26+00:00"
+            "time": "2026-04-15T10:56:54+00:00"
         },
         {
             "name": "nyholm/psr7",
@@ -510,16 +510,16 @@
         },
         {
             "name": "stripe/stripe-php",
-            "version": "v20.0.0",
+            "version": "v20.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/stripe/stripe-php.git",
-                "reference": "7338bd140e641b1f9c7cb602e2de971e14db6b3b"
+                "reference": "6d0ec5ffa0678a408d63163ace1453b35a85fb24"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/stripe/stripe-php/zipball/7338bd140e641b1f9c7cb602e2de971e14db6b3b",
-                "reference": "7338bd140e641b1f9c7cb602e2de971e14db6b3b",
+                "url": "https://api.github.com/repos/stripe/stripe-php/zipball/6d0ec5ffa0678a408d63163ace1453b35a85fb24",
+                "reference": "6d0ec5ffa0678a408d63163ace1453b35a85fb24",
                 "shasum": ""
             },
             "require": {
@@ -566,22 +566,22 @@
             ],
             "support": {
                 "issues": "https://github.com/stripe/stripe-php/issues",
-                "source": "https://github.com/stripe/stripe-php/tree/v20.0.0"
+                "source": "https://github.com/stripe/stripe-php/tree/v20.1.0"
             },
-            "time": "2026-03-26T01:57:48+00:00"
+            "time": "2026-04-24T00:12:56+00:00"
         },
         {
             "name": "xsolla/xsolla-sdk-php",
-            "version": "v4.3.2",
+            "version": "v4.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/xsolla/xsolla-sdk-php.git",
-                "reference": "6bea126a37e7f1a419e61418a7b35cbb04475e33"
+                "reference": "5f8642f7830f4ef3554cf01830cd752b57536da7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/xsolla/xsolla-sdk-php/zipball/6bea126a37e7f1a419e61418a7b35cbb04475e33",
-                "reference": "6bea126a37e7f1a419e61418a7b35cbb04475e33",
+                "url": "https://api.github.com/repos/xsolla/xsolla-sdk-php/zipball/5f8642f7830f4ef3554cf01830cd752b57536da7",
+                "reference": "5f8642f7830f4ef3554cf01830cd752b57536da7",
                 "shasum": ""
             },
             "require": {
@@ -624,7 +624,7 @@
                 "source": "https://github.com/xsolla/xsolla-sdk-php/releases"
             },
             "abandoned": true,
-            "time": "2024-05-23T11:07:08+00:00"
+            "time": "2026-04-02T03:43:47+00:00"
         }
     ],
     "packages-dev": [],
@@ -637,5 +637,5 @@
         "php": ">=8.0"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
     "id": "shop",
     "name": "Shop",
     "description": "A shop plugin to sell in-game items on your website.",
-    "version": "1.2.20",
+    "version": "1.2.21",
     "url": "https://market.azuriom.com/resources/1",
     "authors": [
         "Azuriom"

--- a/src/Payment/Method/StripeMethod.php
+++ b/src/Payment/Method/StripeMethod.php
@@ -16,6 +16,7 @@ use Stripe\Checkout\Session;
 use Stripe\Coupon;
 use Stripe\Exception\SignatureVerificationException;
 use Stripe\Invoice;
+use Stripe\InvoicePayment;
 use Stripe\Stripe;
 use Stripe\Subscription as StripeSubscription;
 use Stripe\Webhook;
@@ -156,7 +157,7 @@ class StripeMethod extends PaymentMethod
 
             $subscription = Subscription::where('subscription_id', $subscriptionId)->firstOrFail();
 
-            return $this->renewSubscription($subscription, $this->getInvoiceTransactionId($invoice));
+            return $this->renewSubscription($subscription, $this->getInvoiceTransactionId($invoice->id));
         }
 
         if ($event->type === 'customer.subscription.deleted') {
@@ -195,12 +196,7 @@ class StripeMethod extends PaymentMethod
                 $sub = $this->createSubscription($user, $package, $session->subscription, $total, $currency);
             }
 
-            $invoice = Invoice::retrieve([
-                'id' => $session->invoice,
-                'expand' => ['payments'],
-            ]);
-
-            return $this->renewSubscription($sub, $this->getInvoiceTransactionId($invoice), true);
+            return $this->renewSubscription($sub, $this->getInvoiceTransactionId($session->invoice), true);
         }
 
         $payment = Payment::find($session->client_reference_id);
@@ -230,13 +226,14 @@ class StripeMethod extends PaymentMethod
     /*
      * Get the PaymentIntent ID attached to a Stripe invoice. See https://docs.stripe.com/api/invoice-payment/object
      */
-    protected function getInvoiceTransactionId(Invoice $invoice): string
+    protected function getInvoiceTransactionId(string $invoiceId): string
     {
-        $paymentIntent = $invoice->payments?->data[0]?->payment?->payment_intent;
+        $payments = InvoicePayment::all(['invoice' => $invoiceId, 'limit' => 1]);
+        $paymentIntent = $payments->data[0]?->payment?->payment_intent ?? null;
 
         if (! is_string($paymentIntent)) {
             throw new RuntimeException(
-                "Stripe invoice {$invoice->id} has no PaymentIntent attached"
+                "Stripe invoice {$invoiceId} has no PaymentIntent attached"
             );
         }
 

--- a/src/Payment/Method/StripeMethod.php
+++ b/src/Payment/Method/StripeMethod.php
@@ -11,6 +11,7 @@ use Azuriom\Plugin\Shop\Models\Subscription;
 use Azuriom\Plugin\Shop\Payment\PaymentMethod;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
+use RuntimeException;
 use Stripe\Checkout\Session;
 use Stripe\Coupon;
 use Stripe\Exception\SignatureVerificationException;
@@ -155,7 +156,7 @@ class StripeMethod extends PaymentMethod
 
             $subscription = Subscription::where('subscription_id', $subscriptionId)->firstOrFail();
 
-            return $this->renewSubscription($subscription, $invoice->id);
+            return $this->renewSubscription($subscription, $this->getInvoiceTransactionId($invoice));
         }
 
         if ($event->type === 'customer.subscription.deleted') {
@@ -194,9 +195,12 @@ class StripeMethod extends PaymentMethod
                 $sub = $this->createSubscription($user, $package, $session->subscription, $total, $currency);
             }
 
-            $invoice = Invoice::retrieve($session->invoice);
+            $invoice = Invoice::retrieve([
+                'id' => $session->invoice,
+                'expand' => ['payments'],
+            ]);
 
-            return $this->renewSubscription($sub, $invoice->id, true);
+            return $this->renewSubscription($sub, $this->getInvoiceTransactionId($invoice), true);
         }
 
         $payment = Payment::find($session->client_reference_id);
@@ -221,6 +225,22 @@ class StripeMethod extends PaymentMethod
             'max_redemptions' => 1,
             'name' => trans('shop::messages.payment.giftcards'),
         ]);
+    }
+
+    /*
+     * Get the PaymentIntent ID attached to a Stripe invoice. See https://docs.stripe.com/api/invoice-payment/object
+     */
+    protected function getInvoiceTransactionId(Invoice $invoice): string
+    {
+        $paymentIntent = $invoice->payments?->data[0]?->payment?->payment_intent;
+
+        if (! is_string($paymentIntent)) {
+            throw new RuntimeException(
+                "Stripe invoice {$invoice->id} has no PaymentIntent attached"
+            );
+        }
+
+        return $paymentIntent;
     }
 
     /*

--- a/src/Payment/Method/StripeMethod.php
+++ b/src/Payment/Method/StripeMethod.php
@@ -11,7 +11,6 @@ use Azuriom\Plugin\Shop\Models\Subscription;
 use Azuriom\Plugin\Shop\Payment\PaymentMethod;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
-use RuntimeException;
 use Stripe\Checkout\Session;
 use Stripe\Coupon;
 use Stripe\Exception\SignatureVerificationException;
@@ -157,7 +156,17 @@ class StripeMethod extends PaymentMethod
 
             $subscription = Subscription::where('subscription_id', $subscriptionId)->firstOrFail();
 
-            return $this->renewSubscription($subscription, $this->getInvoiceTransactionId($invoice->id));
+            $paymentIntentId = $this->paymentIntentForInvoice($invoice);
+
+            if ($paymentIntentId === null) {
+                Log::warning("Stripe invoice {$invoice->id} has no payment intent attached.");
+
+                return response()->json(['status' => 'no_payment_intent'], 400);
+            }
+
+            $this->renewSubscription($subscription, $paymentIntentId);
+
+            return response()->noContent();
         }
 
         if ($event->type === 'customer.subscription.deleted') {
@@ -183,8 +192,7 @@ class StripeMethod extends PaymentMethod
     protected function processCompletedCheckout(Session $session)
     {
         if ($session->mode === 'subscription') {
-            // Stripe may re-deliver checkout.session.completed on retry — look up an
-            // existing subscription before creating one to keep this handler idempotent.
+            // Avoid duplicated subscriptions due to Stripe re-delivering events on error
             $sub = Subscription::firstWhere('subscription_id', $session->subscription);
 
             if ($sub === null) {
@@ -196,7 +204,15 @@ class StripeMethod extends PaymentMethod
                 $sub = $this->createSubscription($user, $package, $session->subscription, $total, $currency);
             }
 
-            return $this->renewSubscription($sub, $this->getInvoiceTransactionId($session->invoice), true);
+            $paymentIntentId = $this->paymentIntentForInvoice($session->invoice);
+
+            if ($paymentIntentId === null) {
+                Log::warning("Stripe invoice {$session->invoice} has no payment intent attached.");
+
+                return response()->json(['status' => 'no_payment_intent'], 400);
+            }
+
+            return $this->renewSubscription($sub, $paymentIntentId, true);
         }
 
         $payment = Payment::find($session->client_reference_id);
@@ -223,21 +239,21 @@ class StripeMethod extends PaymentMethod
         ]);
     }
 
-    /*
-     * Get the PaymentIntent ID attached to a Stripe invoice. See https://docs.stripe.com/api/invoice-payment/object
+    /**
+     * Get the payment intent ID associated with the given Stripe invoice, if any.
      */
-    protected function getInvoiceTransactionId(string $invoiceId): string
+    protected function paymentIntentForInvoice(Invoice|string $invoice): ?string
     {
-        $payments = InvoicePayment::all(['invoice' => $invoiceId, 'limit' => 1]);
-        $paymentIntent = $payments->data[0]?->payment?->payment_intent ?? null;
+        $invoicePayments = InvoicePayment::all([
+            'invoice' => $invoice instanceof Invoice ? $invoice->id : $invoice,
+            'status' => 'paid',
+            'payment' => ['type' => 'payment_intent'],
+            'limit' => 1,
+        ]);
 
-        if (! is_string($paymentIntent)) {
-            throw new RuntimeException(
-                "Stripe invoice {$invoiceId} has no PaymentIntent attached"
-            );
-        }
+        $invoicePayment = $invoicePayments->data[0] ?? null;
 
-        return $paymentIntent;
+        return $invoicePayment?->payment?->payment_intent;
     }
 
     /*

--- a/src/Payment/Method/StripeMethod.php
+++ b/src/Payment/Method/StripeMethod.php
@@ -155,11 +155,7 @@ class StripeMethod extends PaymentMethod
 
             $subscription = Subscription::where('subscription_id', $subscriptionId)->firstOrFail();
 
-            if ($invoice->payment_intent !== null) {
-                $this->renewSubscription($subscription, $invoice->payment_intent);
-            }
-
-            return response()->noContent();
+            return $this->renewSubscription($subscription, $invoice->id);
         }
 
         if ($event->type === 'customer.subscription.deleted') {
@@ -185,15 +181,22 @@ class StripeMethod extends PaymentMethod
     protected function processCompletedCheckout(Session $session)
     {
         if ($session->mode === 'subscription') {
-            $user = User::find($session->metadata['user']);
-            $package = Package::find($session->metadata['package']);
+            // Stripe may re-deliver checkout.session.completed on retry — look up an
+            // existing subscription before creating one to keep this handler idempotent.
+            $sub = Subscription::firstWhere('subscription_id', $session->subscription);
+
+            if ($sub === null) {
+                $user = User::find($session->metadata['user']);
+                $package = Package::find($session->metadata['package']);
+                $currency = $session->currency;
+                $total = $this->retrieveDecimalAmount($session->amount_total, $currency);
+
+                $sub = $this->createSubscription($user, $package, $session->subscription, $total, $currency);
+            }
+
             $invoice = Invoice::retrieve($session->invoice);
-            $currency = $session->currency;
-            $total = $this->retrieveDecimalAmount($session->amount_total, $currency);
 
-            $sub = $this->createSubscription($user, $package, $session->subscription, $total, $currency);
-
-            return $this->renewSubscription($sub, $invoice->payment_intent, true);
+            return $this->renewSubscription($sub, $invoice->id, true);
         }
 
         $payment = Payment::find($session->client_reference_id);


### PR DESCRIPTION
The Invoice::payment_intent property was removed in stripe-php v19, so $invoice->payment_intent silently returns null. This caused two user- visible regressions on every Stripe subscription webhook:

- checkout.session.completed threw a TypeError in renewSubscription() because the second argument became null. Laravel returned a 500, Stripe retried, and each retry ran createSubscription() again, producing duplicate rows in shop_subscriptions (one per retry, at the intervals of Stripe's retry schedule).
- invoice.paid silently skipped every renewal due to a `if (\$invoice->payment_intent !== null)` guard, so recurring charges never extended the subscription, never delivered commands, never notified Discord/email.

Use \$invoice->id as the transaction_id — it is always present, unique per invoice, and serves the existing dedup check in renewSubscription().

Also make processCompletedCheckout idempotent by looking up an existing Subscription by subscription_id before creating one, so any future webhook retry (timeout, transient error, etc.) no longer duplicates rows.