### PR TITLE
Show server name for server-type variables

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
     "id": "shop",
     "name": "Shop",
     "description": "A shop plugin to sell in-game items on your website.",
-    "version": "1.2.22",
+    "version": "1.2.23",
     "url": "https://market.azuriom.com/resources/1",
     "authors": [
         "Azuriom"

--- a/resources/views/admin/payments/show.blade.php
+++ b/resources/views/admin/payments/show.blade.php
@@ -138,7 +138,7 @@
                             <tbody>
 
                             @foreach($payment->items as $item)
-                                @foreach($item->variables ?? [] as $key => $value)
+                                @foreach($item->getFormattedVariables() as $key => $value)
                                     <tr>
                                         <th scope="row">{{ $item->name }}</th>
                                         <td>{{ $key }}</td>

--- a/src/Models/Payment.php
+++ b/src/Models/Payment.php
@@ -250,7 +250,7 @@ class Payment extends Model
             if (! empty($item->variables)) {
                 $lines[] = trans('shop::messages.payment.variables');
 
-                foreach ($item->variables as $key => $value) {
+                foreach ($item->getFormattedVariables() as $key => $value) {
                     $lines[] = "- **`{{$key}}`** {$value}";
                 }
             }

--- a/src/Models/PaymentItem.php
+++ b/src/Models/PaymentItem.php
@@ -115,7 +115,7 @@ class PaymentItem extends Model
     public function getFormattedVariables(): array
     {
         if (empty($this->variables) || ! ($this->buyable instanceof Package)) {
-            return [];
+            return $this->variables;
         }
 
         $serverVar = $this->buyable->variables->where('type', 'server')->pluck('name');

--- a/src/Models/PaymentItem.php
+++ b/src/Models/PaymentItem.php
@@ -2,10 +2,12 @@
 
 namespace Azuriom\Plugin\Shop\Models;
 
+use Azuriom\Models\Server;
 use Azuriom\Models\Traits\HasTablePrefix;
 use Azuriom\Plugin\Shop\Payment\Currencies;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
 
 /**
  * @property int $id
@@ -108,6 +110,33 @@ class PaymentItem extends Model
         $search = array_map(fn (string $key) => '{'.$key.'}', array_keys($this->variables));
 
         return str_replace($search, $this->variables, $content);
+    }
+
+    public function getFormattedVariables(): array
+    {
+        if (empty($this->variables)) {
+            return [];
+        }
+
+        $serverNames = ($this->buyable instanceof Package)
+            ? $this->buyable->variables->where('type', 'server')->pluck('name')->all()
+            : [];
+
+        if (empty($serverNames)) {
+            return $this->variables
+        }
+
+        $servers = Server::findMany(Arr::only($this->variables, $serverNames))->keyBy('id');
+
+        return collect($this->variables)
+            ->map(function ($value, $key) use ($serverNames, $servers) {
+                if (in_array($key, $serverNames, true) && ($server = $servers->get($value)) !== null) {
+                    return $server->name.' (#'.$value.')';
+                }
+
+                return $value;
+            })
+            ->all();
     }
 
     public function isExpired(): bool

--- a/src/Models/PaymentItem.php
+++ b/src/Models/PaymentItem.php
@@ -115,7 +115,7 @@ class PaymentItem extends Model
     public function getFormattedVariables(): array
     {
         if (empty($this->variables) || ! ($this->buyable instanceof Package)) {
-            return $this->variables;
+            return $this->variables ?? [];
         }
 
         $serverVar = $this->buyable->variables->where('type', 'server')->pluck('name');

--- a/src/Models/PaymentItem.php
+++ b/src/Models/PaymentItem.php
@@ -123,7 +123,7 @@ class PaymentItem extends Model
             : [];
 
         if (empty($serverNames)) {
-            return $this->variables
+            return $this->variables;
         }
 
         $servers = Server::findMany(Arr::only($this->variables, $serverNames))->keyBy('id');

--- a/src/Models/PaymentItem.php
+++ b/src/Models/PaymentItem.php
@@ -114,29 +114,25 @@ class PaymentItem extends Model
 
     public function getFormattedVariables(): array
     {
-        if (empty($this->variables)) {
+        if (empty($this->variables) || ! ($this->buyable instanceof Package)) {
             return [];
         }
 
-        $serverNames = ($this->buyable instanceof Package)
-            ? $this->buyable->variables->where('type', 'server')->pluck('name')->all()
-            : [];
+        $serverVar = $this->buyable->variables->where('type', 'server')->pluck('name');
 
-        if (empty($serverNames)) {
+        if ($serverVar->isEmpty()) {
             return $this->variables;
         }
 
-        $servers = Server::findMany(Arr::only($this->variables, $serverNames))->keyBy('id');
-
-        return collect($this->variables)
-            ->map(function ($value, $key) use ($serverNames, $servers) {
-                if (in_array($key, $serverNames, true) && ($server = $servers->get($value)) !== null) {
-                    return $server->name.' (#'.$value.')';
-                }
-
-                return $value;
-            })
+        $servers = Server::whereKey(Arr::only($this->variables, $serverVar->all()))
+            ->pluck('name', 'id')
+            ->map(fn (string $name, int $id) => $name.' (#'.$id.')')
             ->all();
+
+        return Arr::map(
+            $this->variables,
+            fn (string $val, $name) => $serverVar->contains($name) ? ($servers[$val] ?? $val) : $val
+        );
     }
 
     public function isExpired(): bool


### PR DESCRIPTION
The webhook and admin payment view only showed the raw server id. The server name is now displayed too.