### PR TITLE
Option to mark packages as unavailable

### DIFF
--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -124,6 +124,7 @@ return [
     ],
 
     'packages' => [
+        'unavailable' => 'This package is not available.',
         'limit' => 'You have purchased the maximum possible for this packages.',
         'requirements' => 'You don\'t have the requirements to purchase this package.',
         'cumulate' => 'You cannot buy this package with an other from the same category in the same purchase.',

--- a/resources/lang/fr/messages.php
+++ b/resources/lang/fr/messages.php
@@ -124,6 +124,7 @@ return [
     ],
 
     'packages' => [
+        'unavailable' => 'Ce produit n\'est pas disponible',
         'limit' => 'Vous avez acheté le maximum possible pour cet article.',
         'requirements' => 'Vous n\'avez pas les pré-requis pour acheter cet article.',
         'cumulate' => 'Vous ne pouvez pas acheter ce produit avec un autre de la même catégorie dans le même achat.',

--- a/resources/views/admin/packages/_form.blade.php
+++ b/resources/views/admin/packages/_form.blade.php
@@ -165,11 +165,12 @@
 </div>
 
 <div class="mb-3 form-check form-switch">
-    <input type="checkbox" class="form-check-input" id="userLimitSwitch" name="has_user_limit" data-bs-toggle="collapse" data-bs-target="#userLimit" @checked(old('user_limit', $package->user_limit ?? false))>
+    <input type="checkbox" class="form-check-input" id="userLimitSwitch" name="has_user_limit" data-bs-toggle="collapse"
+           data-bs-target="#userLimit" @checked(old('user_limit', $package->user_limit ?? null) !== null)>
     <label class="form-check-label" for="userLimitSwitch">{{ trans('shop::admin.packages.has_user_limit') }}</label>
 </div>
 
-<div id="userLimit" class="{{ old('user_limit', $package->user_limit ?? false) ? 'show' : 'collapse' }}">
+<div id="userLimit" class="{{ old('user_limit', $package->user_limit ?? null) !== null ? 'show' : 'collapse' }}">
     <div class="card mb-3">
         <div class="card-body row gx-3">
             <div class="mb-3 col-md-6">
@@ -212,11 +213,12 @@
 </div>
 
 <div class="mb-3 form-check form-switch">
-    <input type="checkbox" class="form-check-input" id="globalLimitSwitch" name="has_global_limit" data-bs-toggle="collapse" data-bs-target="#globalLimit" @checked(old('global_limit', $package->global_limit ?? false))>
+    <input type="checkbox" class="form-check-input" id="globalLimitSwitch" name="has_global_limit" data-bs-toggle="collapse"
+           data-bs-target="#globalLimit" @checked(old('global_limit', $package->global_limit ?? null) !== null)>
     <label class="form-check-label" for="globalLimitSwitch">{{ trans('shop::admin.packages.has_global_limit') }}</label>
 </div>
 
-<div id="globalLimit" class="{{ old('global_limit', $package->global_limit ?? false) ? 'show' : 'collapse' }}">
+<div id="globalLimit" class="{{ old('global_limit', $package->global_limit ?? null) !== null ? 'show' : 'collapse' }}">
     <div class="card mb-3">
         <div class="card-body row gx-3">
             <div class="mb-3 col-md-6">

--- a/resources/views/categories/show.blade.php
+++ b/resources/views/categories/show.blade.php
@@ -58,9 +58,15 @@
                                     {{ shop_format_amount($package->getPrice()) }}
                                 </h5>
 
-                                <a href="#" class="btn btn-primary" data-package-url="{{ route('shop.packages.show', $package) }}">
-                                    {{ trans('shop::messages.buy') }}
-                                </a>
+                                @if($package->getMaxQuantity() < 1)
+                                    <button class="btn btn-danger disabled" disabled>
+                                        <i class="bi bi-x-circle"></i> Out of Stock
+                                    </button>
+                                @else
+                                    <a href="#" class="btn btn-primary" data-package-url="{{ route('shop.packages.show', $package) }}">
+                                        {{ trans('shop::messages.buy') }}
+                                    </a>
+                                @endif
                             </div>
                         </div>
                     </div>

--- a/resources/views/categories/show.blade.php
+++ b/resources/views/categories/show.blade.php
@@ -58,15 +58,9 @@
                                     {{ shop_format_amount($package->getPrice()) }}
                                 </h5>
 
-                                @if($package->getMaxQuantity() < 1)
-                                    <button class="btn btn-danger disabled" disabled>
-                                        <i class="bi bi-x-circle"></i> Out of Stock
-                                    </button>
-                                @else
-                                    <a href="#" class="btn btn-primary" data-package-url="{{ route('shop.packages.show', $package) }}">
-                                        {{ trans('shop::messages.buy') }}
-                                    </a>
-                                @endif
+                                <a href="#" class="btn btn-primary" data-package-url="{{ route('shop.packages.show', $package) }}">
+                                    {{ trans('shop::messages.buy') }}
+                                </a>
                             </div>
                         </div>
                     </div>

--- a/resources/views/packages/show.blade.php
+++ b/resources/views/packages/show.blade.php
@@ -38,12 +38,12 @@
                             <i class="bi bi-cart-x"></i> {{ trans('messages.actions.remove') }}
                         </button>
                     </form>
+                @elseif($package->global_limit === 0)
+                    <i class="bi bi-x-circle"></i> {{ trans('shop::messages.packages.unavailable') }}
                 @elseif($package->getMaxQuantity() < 1)
-                    <button class="btn btn-danger disabled" disabled>
-                        <i class="bi bi-x-circle"></i> Out of Stock
-                    </button>
+                    <i class="bi bi-x-circle"></i> {{ trans('shop::messages.packages.limit') }}
                 @elseif(! $package->hasBoughtRequirements())
-                    {{ trans('shop::messages.packages.requirements') }}
+                    <i class="bi bi-x-circle"></i> {{ trans('shop::messages.packages.requirements') }}
                 @else
                     <form action="{{ route('shop.packages.buy', $package) }}" method="POST" class="row row-cols-lg-auto g-0 gy-2 align-items-center">
                         @csrf

--- a/resources/views/packages/show.blade.php
+++ b/resources/views/packages/show.blade.php
@@ -39,7 +39,9 @@
                         </button>
                     </form>
                 @elseif($package->getMaxQuantity() < 1)
-                    {{ trans('shop::messages.packages.limit') }}
+                    <button class="btn btn-danger disabled" disabled>
+                        <i class="bi bi-x-circle"></i> Out of Stock
+                    </button>
                 @elseif(! $package->hasBoughtRequirements())
                     {{ trans('shop::messages.packages.requirements') }}
                 @else

--- a/src/Models/Package.php
+++ b/src/Models/Package.php
@@ -312,7 +312,7 @@ class Package extends Model implements Buyable
 
     public function getMaxQuantity(): int
     {
-        if ($this->cumulativePurchasesBlocked()) {
+        if ($this->global_limit === 0 || $this->cumulativePurchasesBlocked()) {
             return 0;
         }
 

--- a/src/Models/Package.php
+++ b/src/Models/Package.php
@@ -320,10 +320,10 @@ class Package extends Model implements Buyable
         $globalStart = optional($this->global_limit_period, fn ($period) => now()->sub($period));
         $noExpired = $this->limits_no_expired;
 
-        $user = $this->user_limit > 0
+        $user = $this->user_limit !== null
             ? $this->user_limit - $this->countUserPurchases($userStart, $noExpired)
             : 100;
-        $global = $this->global_limit > 0
+        $global = $this->global_limit !== null
             ? $this->global_limit - $this->countTotalPurchases($globalStart, $noExpired)
             : 100;
 

--- a/src/Requests/PackageRequest.php
+++ b/src/Requests/PackageRequest.php
@@ -46,7 +46,7 @@ class PackageRequest extends FormRequest
             'billing_period' => ['required_if:billing_type,expiring,subscription', self::PERIOD_RULE],
             'user_limit' => ['nullable', 'integer', 'gt:0'],
             'user_limit_period' => ['nullable', self::PERIOD_RULE],
-            'global_limit' => ['nullable', 'integer', 'gt:0'],
+            'global_limit' => ['nullable', 'integer', 'min:0'],
             'global_limit_period' => ['nullable', self::PERIOD_RULE],
             'limits_no_expired' => ['filled', 'boolean'],
             'servers.*' => ['required', 'exists:servers,id'],


### PR DESCRIPTION
This PR addresses an issue where `global_limit` could not be set to `0` from the admin panel, and updates the storefront to display an 'Out of Stock' button when the limit is reached or set to 0.

### Changes:
- Modified `global_limit` validation rule in `PackageRequest.php` from `gt:0` to `min:0`.
- Updated `getMaxQuantity()` in `Package.php` to check `!== null` instead of `> 0`, ensuring that an explicit limit of `0` is respected.
- Updated `categories/show.blade.php` and `packages/show.blade.php` to display a disabled 'Out of Stock' button when a package's available quantity falls below 1.