### PR TITLE
Fix price validation for custom price packages with an active discount

### DIFF
--- a/src/Controllers/PackageController.php
+++ b/src/Controllers/PackageController.php
@@ -42,7 +42,7 @@ class PackageController extends Controller
     {
         $this->validate($request, [
             'quantity' => 'nullable|integer',
-            'price' => 'sometimes|nullable|numeric|min:'.$package->price,
+            'price' => 'sometimes|nullable|numeric|min:'.$package->getPrice(),
         ]);
 
         if ($package->isSubscription()) {
@@ -93,7 +93,7 @@ class PackageController extends Controller
         $this->validate($request, [
             ...$rules->all(),
             'quantity' => 'nullable|integer',
-            'price' => 'sometimes|nullable|numeric|min:'.$package->price,
+            'price' => 'sometimes|nullable|numeric|min:'.$package->getPrice(),
         ]);
 
         $checkboxes = $package->variables


### PR DESCRIPTION
When custom price option is activated in a product and a discount is active, the server side verification fails because the discounted price is below the minimal price. I think the minimal price should be the discounted price, not the initial one.